### PR TITLE
Some refactoring

### DIFF
--- a/src/main/java/ru/anr/base/BaseParent.java
+++ b/src/main/java/ru/anr/base/BaseParent.java
@@ -359,7 +359,7 @@ public class BaseParent {
      *            Object type
      */
     @SuppressWarnings("unchecked")
-    public static <S> S clone(Cloneable o) {
+    public static <S> S clone(Object o) {
 
         return (S) org.apache.commons.lang3.ObjectUtils.cloneIfPossible(o);
     }

--- a/src/main/java/ru/anr/base/BaseParent.java
+++ b/src/main/java/ru/anr/base/BaseParent.java
@@ -359,7 +359,7 @@ public class BaseParent {
      *            Object type
      */
     @SuppressWarnings("unchecked")
-    public static <S> S clone(Object o) {
+    public static <S> S cloneObject(Object o) {
 
         return (S) org.apache.commons.lang3.ObjectUtils.cloneIfPossible(o);
     }

--- a/src/main/java/ru/anr/base/BaseSpringParent.java
+++ b/src/main/java/ru/anr/base/BaseSpringParent.java
@@ -109,6 +109,18 @@ public class BaseSpringParent extends BaseParent {
         return (S) ctx.getBean(name);
     }
 
+    /**
+     * Returns true if specified bean exists
+     * 
+     * @param name
+     *            Name of the bean
+     * @return true if bean exists
+     */
+    protected boolean hasBean(String name) {
+
+        return ctx.containsBean(name);
+    }
+
     // /////////////////////////////////////////////////////////////////////////
     // /// getters/setters
     // /////////////////////////////////////////////////////////////////////////

--- a/src/test/java/ru/anr/base/BaseParentTest.java
+++ b/src/test/java/ru/anr/base/BaseParentTest.java
@@ -359,8 +359,8 @@ public class BaseParentTest extends BaseParent {
     public void testClone() {
 
         Calendar calendar = Calendar.getInstance();
-        clone(calendar);
-        Assert.assertEquals(calendar, clone(calendar));
+        cloneObject(calendar);
+        Assert.assertEquals(calendar, cloneObject(calendar));
     }
 
     /**


### PR DESCRIPTION
replaced clone() to cloneObject() to avoid confusing. Added method hasBean() to check if bean exists